### PR TITLE
Null check ItemChangerMod.Modules

### DIFF
--- a/BenchRando/Rando/RandoInterop.cs
+++ b/BenchRando/Rando/RandoInterop.cs
@@ -87,7 +87,7 @@ namespace BenchRando.Rando
 
         private static void OnLogSettings(RandomizerMod.Logging.LogArguments args, TextWriter tw)
         {
-            if (ItemChangerMod.Modules.Get<IC.BRLocalSettingsModule>() is { LS.Settings: BenchRandomizationSettings randoSettings })
+            if (ItemChangerMod.Modules?.Get<IC.BRLocalSettingsModule>() is { LS.Settings: BenchRandomizationSettings randoSettings })
             {
                 tw.WriteLine("Logging BenchRando BenchRandomizationSettings:");
                 using JsonTextWriter jtw = new(tw) { CloseOutput = false };


### PR DESCRIPTION
Use case - if someone wanted to generate logs without entering file. (Although they still could not enter the file if benches are randomized)